### PR TITLE
Add UI theming and expanded control documentation 

### DIFF
--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -382,7 +382,7 @@ class GenerateStories extends Command
             }
 
             if (Arr::has($options, 'order')) {
-                $data['order'] = (float) $options['order'];
+                $data['order'] = $options['order'];
             }
         }
 

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -45,6 +45,7 @@ class Publish extends Command
         $this->vendorPath = $this->getVendorPath();
         $this->storybookStatuses = config('blast.storybook_statuses');
         $this->storybookTheme = config('blast.storybook_theme', false);
+        $this->storybookSortOrder = config('blast.storybook_sort_order', []);
         $this->storybookGlobalTypes = config(
             'blast.storybook_global_types',
             [],
@@ -115,6 +116,7 @@ class Publish extends Command
             'LIBSTORYPATH' => $this->vendorPath . '/stories',
             'PROJECTPATH' => base_path(),
             'COMPONENTPATH' => base_path('resources/views/stories'),
+            'STORYBOOK_SORT_ORDER' => json_encode($this->storybookSortOrder),
         ]);
 
         usleep(250000);


### PR DESCRIPTION
Hi, I've opened this pull request to add the ability to change theme from blast.php between default(light) and dark theme for both the canvas and docs pages.  Also included within the PR is the ability to defne a custom theme from blast.php

Another addition is to enable expanded documentation in the controls tab via a bool in blast.php.  To render the description add 'description' to argTypes within @storybook blade directive, e.g.

```
'color' =>[
            'options' => [
                'text-light', 'text-primary', 'text-dark', 'text-dark'
            ],
            'control' => [
                'type' => 'select'
        ],
            'description' => 'bootstrap 5 classes for text-color'
   ],
```
![Storybook_dark_expanded_controls](https://user-images.githubusercontent.com/59289145/141535521-57e02ea4-9954-4efe-9e13-1854ff3d5f8b.JPG)
